### PR TITLE
feat: Implement client-side OCO order management

### DIFF
--- a/futuresdeskapi/client.py
+++ b/futuresdeskapi/client.py
@@ -6,6 +6,9 @@ from .position import PositionAPI
 from .trade import TradeAPI
 from .history import HistoryAPI
 from .realtime import RealTimeClient
+from .oco_manager import OcoManager
+# Optional: import logging if uncommenting logging lines
+# import logging
 
 
 class FuturesDeskClient:
@@ -21,3 +24,77 @@ class FuturesDeskClient:
         self.position = PositionAPI(self.token, self.base_url)
         self.trade = TradeAPI(self.token, self.base_url)
         self.history = HistoryAPI(self.token, self.base_url)
+        self.oco_manager = OcoManager(order_api_client=self.order, position_api_client=self.position)
+
+    def place_oco_order(
+        self,
+        account_id: int,
+        contract_id: str,
+        position_side: int,
+        size: int,
+        stop_loss_price: float,
+        take_profit_price: float,
+        custom_tag_sl: str = None,
+        custom_tag_tp: str = None
+    ):
+        '''
+        Places an OCO (One-Cancels-the-Other) order and registers it with the OCO manager.
+        Returns:
+            tuple: (sl_order_id, tp_order_id, client_oco_id) if successful.
+        Raises:
+            Exception from self.order.place_oco_order if placement fails.
+        '''
+        # The place_oco_order in OrderAPI will raise an exception if a leg fails,
+        # potentially including the ID of a successfully placed first leg.
+        sl_order_id, tp_order_id = self.order.place_oco_order(
+            account_id=account_id,
+            contract_id=contract_id,
+            position_side=position_side,
+            size=size,
+            stop_loss_price=stop_loss_price,
+            take_profit_price=take_profit_price,
+            custom_tag_sl=custom_tag_sl,
+            custom_tag_tp=custom_tag_tp
+        )
+
+        # If the above call succeeded, both sl_order_id and tp_order_id are valid.
+        client_oco_id = f"oco_{sl_order_id}_{tp_order_id}"
+        self.oco_manager.add_oco_pair(
+            client_oco_id=client_oco_id,
+            sl_order_id=sl_order_id,
+            tp_order_id=tp_order_id,
+            account_id=account_id,
+            contract_id=contract_id
+        )
+        # logging.info(f"FuturesDeskClient: Registered OCO pair {client_oco_id} for contract {contract_id}")
+        return sl_order_id, tp_order_id, client_oco_id
+
+    def start_oco_manager(self, polling_interval: int = None):
+        '''Starts the OCO manager polling thread.'''
+        if hasattr(self, 'oco_manager') and self.oco_manager:
+            if polling_interval is not None:
+                self.oco_manager.polling_interval = polling_interval
+            self.oco_manager.start()
+            # logging.info("FuturesDeskClient: OCO Manager started.")
+        else:
+            # logging.error("FuturesDeskClient: OcoManager not initialized.")
+            raise Exception("OcoManager not initialized.")
+
+    def stop_oco_manager(self):
+        '''Stops the OCO manager polling thread.'''
+        if hasattr(self, 'oco_manager') and self.oco_manager:
+            self.oco_manager.stop()
+            # logging.info("FuturesDeskClient: OCO Manager stopped.")
+        else:
+            # logging.warning("FuturesDeskClient: OcoManager not initialized or already stopped.")
+            pass # Or raise error if strictness is needed
+
+    def __del__(self):
+        # Attempt to stop the OCO manager when the client object is garbage collected.
+        # Note: __del__ is not guaranteed to be called reliably in all Python implementations
+        # or all circumstances (e.g., if objects are part of cycles).
+        # Explicitly calling stop_oco_manager() is safer.
+        if hasattr(self, 'oco_manager') and self.oco_manager:
+            if self.oco_manager.polling_thread is not None and self.oco_manager.polling_thread.is_alive():
+                # logging.info("FuturesDeskClient __del__: Stopping OCO manager.")
+                self.oco_manager.stop()

--- a/futuresdeskapi/oco_manager.py
+++ b/futuresdeskapi/oco_manager.py
@@ -1,0 +1,147 @@
+import threading
+import time
+import logging # Optional: for logging within the manager
+
+# Configure basic logging for the OCO Manager (optional)
+# logging.basicConfig(level=logging.INFO, format='%(asctime)s - OCOManager - %(levelname)s - %(message)s')
+
+class OcoManager:
+    def __init__(self, order_api_client, position_api_client, polling_interval=10):
+        self.order_api_client = order_api_client
+        self.position_api_client = position_api_client
+        self.active_oco_orders = {}  # Stores active OCO pairs
+        self.polling_interval = polling_interval  # seconds
+        self._lock = threading.Lock() # To ensure thread-safe access to active_oco_orders
+
+        self.polling_thread = None
+        self.stop_event = threading.Event()
+
+    def add_oco_pair(self, client_oco_id: str, sl_order_id: str, tp_order_id: str, account_id: int, contract_id: str):
+        with self._lock:
+            if client_oco_id in self.active_oco_orders:
+                # logging.warning(f"OCO pair with ID {client_oco_id} already exists. Overwriting.")
+                pass # Or raise error
+            self.active_oco_orders[client_oco_id] = {
+                "sl_order_id": sl_order_id,
+                "tp_order_id": tp_order_id,
+                "account_id": account_id,
+                "contract_id": contract_id,
+                "status": "active" # Potential statuses: active, cancelling_sl, cancelling_tp, completed
+            }
+        # logging.info(f"Added OCO pair {client_oco_id}: SL {sl_order_id}, TP {tp_order_id} for contract {contract_id}")
+
+    def remove_oco_pair(self, client_oco_id: str):
+        with self._lock:
+            if client_oco_id in self.active_oco_orders:
+                del self.active_oco_orders[client_oco_id]
+                # logging.info(f"Removed OCO pair {client_oco_id}")
+                return True
+            # logging.warning(f"Attempted to remove non-existent OCO pair {client_oco_id}")
+            return False
+
+    def _get_active_oco_pairs_copy(self):
+        with self._lock:
+            return dict(self.active_oco_orders) # Return a shallow copy
+
+    def _poll_oco_orders(self):
+        # logging.info("OCO polling thread started.")
+        while not self.stop_event.is_set():
+            try:
+                active_pairs = self._get_active_oco_pairs_copy()
+                if not active_pairs:
+                    self.stop_event.wait(self.polling_interval) # Wait if no active OCOs
+                    continue
+
+                for client_oco_id, oco_data in active_pairs.items():
+                    if self.stop_event.is_set(): break # Exit early if stop requested
+
+                    # logging.debug(f"Polling OCO pair: {client_oco_id}")
+
+                    # 1. Check position status first
+                    try:
+                        open_positions = self.position_api_client.search_open_positions(account_id=oco_data["account_id"])
+                        position_exists_for_contract = any(
+                            p['contractId'] == oco_data["contract_id"] and abs(p.get('size', 0)) > 0 # Assuming 'size' indicates position quantity
+                            for p in open_positions
+                        )
+
+                        if not position_exists_for_contract:
+                            # logging.info(f"Position for contract {oco_data['contract_id']} (OCO: {client_oco_id}) is closed or zero. Cancelling both legs.")
+                            self._cancel_leg(oco_data["account_id"], oco_data["sl_order_id"], "SL", client_oco_id)
+                            self._cancel_leg(oco_data["account_id"], oco_data["tp_order_id"], "TP", client_oco_id)
+                            self.remove_oco_pair(client_oco_id)
+                            continue 
+                    except Exception as e:
+                        # logging.error(f"Error checking position status for OCO {client_oco_id}: {e}")
+                        # Decide if we should continue or skip this pair for now
+                        continue # For now, skip to next OCO pair on error
+
+                    # 2. Fetch open orders for the account
+                    try:
+                        open_api_orders = self.order_api_client.search_open_orders(account_id=oco_data["account_id"])
+                        open_order_ids = {str(o['id']) for o in open_api_orders} # API might return int or str for orderId
+                    except Exception as e:
+                        # logging.error(f"Error fetching open orders for account {oco_data['account_id']} (OCO: {client_oco_id}): {e}")
+                        continue # Skip this OCO pair for this cycle
+
+                    sl_id_str = str(oco_data["sl_order_id"])
+                    tp_id_str = str(oco_data["tp_order_id"])
+
+                    # 3. Check SL order
+                    if sl_id_str not in open_order_ids:
+                        # logging.info(f"SL order {sl_id_str} (OCO: {client_oco_id}) not open (filled/cancelled). Cancelling TP order {tp_id_str}.")
+                        self._cancel_leg(oco_data["account_id"], tp_id_str, "TP", client_oco_id)
+                        self.remove_oco_pair(client_oco_id)
+                        continue
+
+                    # 4. Check TP order
+                    if tp_id_str not in open_order_ids:
+                        # logging.info(f"TP order {tp_id_str} (OCO: {client_oco_id}) not open (filled/cancelled). Cancelling SL order {sl_id_str}.")
+                        self._cancel_leg(oco_data["account_id"], sl_id_str, "SL", client_oco_id)
+                        self.remove_oco_pair(client_oco_id)
+                        continue
+                    
+                    # logging.debug(f"OCO pair {client_oco_id} is still active.")
+
+            except Exception as e:
+                # logging.error(f"Error in OCO polling loop: {e}")
+                # Avoid crashing the thread. Specific errors should be handled above.
+                pass
+            
+            self.stop_event.wait(self.polling_interval) # Wait before next poll cycle
+        # logging.info("OCO polling thread stopped.")
+
+    def _cancel_leg(self, account_id, order_id_to_cancel, leg_name, client_oco_id_context):
+        try:
+            # First, check if it's still open to avoid redundant cancellations if API is slow
+            # This check might be too much if search_open_orders is slow.
+            # open_orders_check = self.order_api_client.search_open_orders(account_id=account_id)
+            # if not any(str(o['id']) == str(order_id_to_cancel) for o in open_orders_check):
+            #     logging.info(f"{leg_name} order {order_id_to_cancel} (OCO: {client_oco_id_context}) already not open. No cancellation needed.")
+            #     return
+
+            self.order_api_client.cancel_order(account_id=account_id, order_id=order_id_to_cancel)
+            # logging.info(f"Successfully cancelled {leg_name} order {order_id_to_cancel} (OCO: {client_oco_id_context}).")
+        except Exception as e:
+            # logging.error(f"Failed to cancel {leg_name} order {order_id_to_cancel} (OCO: {client_oco_id_context}): {e}")
+            # Further error handling/retry could be added here.
+            # If cancellation fails, the order might remain active.
+            pass
+
+
+    def start(self):
+        if self.polling_thread is not None and self.polling_thread.is_alive():
+            # logging.warning("OCO polling thread already running.")
+            return
+
+        self.stop_event.clear()
+        self.polling_thread = threading.Thread(target=self._poll_oco_orders, daemon=True)
+        self.polling_thread.start()
+        # logging.info("OCO Manager started.")
+
+    def stop(self):
+        # logging.info("Stopping OCO Manager...")
+        self.stop_event.set()
+        if self.polling_thread is not None and self.polling_thread.is_alive():
+            self.polling_thread.join()
+        # logging.info("OCO Manager stopped.")

--- a/futuresdeskapi/order.py
+++ b/futuresdeskapi/order.py
@@ -29,6 +29,70 @@ class OrderAPI:
         else:
             raise Exception(f"HTTP Error: {response.status_code} {response.text}")
 
+    def place_oco_order(
+        self,
+        account_id: int,
+        contract_id: str,
+        position_side: int,  # Side of the main position (1 for Buy, 2 for Sell)
+        size: int,
+        stop_loss_price: float,
+        take_profit_price: float,
+        custom_tag_sl: str = None, # Optional custom tag for SL
+        custom_tag_tp: str = None  # Optional custom tag for TP
+    ):
+        """
+        Places a One-Cancels-the-Other (OCO) order, consisting of a stop-loss and a take-profit order.
+        Note: The API does not natively support OCO orders. This function places two separate orders.
+        It's the responsibility of a higher-level component or the user to manage these orders
+        as an OCO group (e.g., cancel one if the other fills).
+        """
+
+        if position_side == 1:  # Main position is Buy
+            sl_side = 2  # Sell
+            tp_side = 2  # Sell
+        elif position_side == 2:  # Main position is Sell
+            sl_side = 1  # Buy
+            tp_side = 1  # Buy
+        else:
+            raise ValueError("position_side must be 1 (Buy) or 2 (Sell)")
+
+        # Assumptions for order types based on typical API behavior:
+        # Type 3: Stop Order (for stop-loss)
+        # Type 2: Limit Order (for take-profit)
+        # These should be verified with the actual API documentation if available.
+        stop_loss_order_type = 3
+        take_profit_order_type = 2
+
+        sl_order_id = None
+        try:
+            sl_order_id = self.place_order(
+                account_id=account_id,
+                contract_id=contract_id,
+                type=stop_loss_order_type,
+                side=sl_side,
+                size=size,
+                stop_price=stop_loss_price,
+                custom_tag=custom_tag_sl
+            )
+
+            tp_order_id = self.place_order(
+                account_id=account_id,
+                contract_id=contract_id,
+                type=take_profit_order_type,
+                side=tp_side,
+                size=size,
+                limit_price=take_profit_price,
+                custom_tag=custom_tag_tp
+            )
+            return sl_order_id, tp_order_id
+        except Exception as e:
+            # If the TP order fails after SL order was placed, include SL order ID in the exception.
+            if sl_order_id is not None:
+                raise Exception(f"Failed to place take-profit order. Stop-loss order (ID: {sl_order_id}) was placed. Original error: {e}")
+            else:
+                # Exception from placing SL order
+                raise e
+
     def search_open_orders(self, account_id: int):
         url = f"{self.base_url}/api/Order/searchOpen"
         headers = {


### PR DESCRIPTION
This commit introduces a client-side One-Cancels-the-Other (OCO) order management system to the `futuresdeskapi` package.

Key changes include:

1.  **`OcoManager` Class (`futuresdeskapi/oco_manager.py`):**
    *   A new class that manages active OCO pairs using a polling mechanism.
    *   It periodically checks the status of positions and open orders.
    *   If a position corresponding to an OCO pair is closed, or if one
        leg of an OCO order (stop-loss or take-profit) is filled or
        manually cancelled, the manager attempts to cancel the other leg.
    *   Includes methods to start and stop the polling thread.

2.  **`OrderAPI` Enhancements (`futuresdeskapi/order.py`):**
    *   Added a new `place_oco_order` method that places two separate
        orders (stop-loss and take-profit) and returns their respective
        order IDs.
    *   Includes error handling to report the ID of a successfully placed
        first leg if the second leg fails.

3.  **`FuturesDeskClient` Integration (`futuresdeskapi/client.py`):**
    *   Instantiates `OcoManager`.
    *   Provides a `place_oco_order` method that calls the `OrderAPI`'s
        equivalent and then registers the OCO pair with the `OcoManager`.
    *   Adds `start_oco_manager` and `stop_oco_manager` methods to control
        the OCO polling service.
    *   Includes a `__del__` method to attempt to stop the `OcoManager`
        on client garbage collection.

4.  **Documentation (`README.md`):**
    *   Added a new section explaining the OCO functionality.
    *   Details how to use it (starting/stopping the manager, placing OCO orders).
    *   Highlights important caveats, such as its client-side nature,
        reliance on polling, potential delays, and lack of guarantees
        compared to server-side OCO.

This feature allows you to simulate OCO behavior by having the client application monitor and manage the orders. You should be aware of the limitations inherent in a client-side polling approach.